### PR TITLE
Add phase shift feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - 🔊 Real-time Web Audio playback using `AudioWorklet`
 - ⚡ WebSocket-powered DSP backend in Python (CUDA with PyTorch or CuPy)
 - 🧪 Full EEG-band targeting: Delta, Theta, Alpha, Beta, Gamma
-- 🎛️ Adjustable carriers, beat frequencies, sweep ranges, and phase offsets
+ - 🎛️ Adjustable carriers, beat frequencies, sweep ranges, and channel phase offsets
 - 🧬 Modular architecture ready for future EEG feedback integration
 - 🧠 Experimental **resonance feedback AI agent** (coming soon)
 - 🌐 Cross-platform UI in-browser (works on Linux/Windows/macOS)
@@ -72,7 +72,7 @@ python server.py --test-sweep
 cd www && python -m http.server 8000
 ```
 
-Then open `http://localhost:8000` in your browser and use the UI controls to adjust carrier frequency, beat frequency and mode.
+Then open `http://localhost:8000` in your browser and use the UI controls to adjust carrier frequency, beat frequency, phase shift and mode.
 
 ### Quick Ubuntu Setup
 

--- a/server.py
+++ b/server.py
@@ -37,6 +37,9 @@ def validate_params(params):
     if not (0.1 <= params.get('beat', 10.0) <= 30.0):
         print("Beat frequency out of range. Setting to default (10.0).")
         params['beat'] = 10.0
+    if not (0.0 <= params.get('phase_shift', 0.0) <= 360.0):
+        print("Phase shift out of range. Setting to default (0.0).")
+        params['phase_shift'] = 0.0
     # You may add more param validation as needed
 
 def play_test_sweep(duration=5.0, start=200.0, end=800.0):
@@ -50,7 +53,12 @@ def play_test_sweep(duration=5.0, start=200.0, end=800.0):
 
 async def audio_stream(websocket):
     generator = BeatGenerator(sample_rate=SAMPLE_RATE, block_size=BLOCK_SIZE)
-    params = {'carrier': 400.0, 'beat': 10.0, 'mode': 'binaural'}
+    params = {
+        'carrier': 400.0,
+        'beat': 10.0,
+        'mode': 'binaural',
+        'phase_shift': 0.0,
+    }
 
     async def recv_loop():
         async for msg in websocket:

--- a/www/app.js
+++ b/www/app.js
@@ -28,8 +28,9 @@ async function start() {
 function sendParams() {
   const carrier = parseFloat(document.getElementById('carrier').value);
   const beat = parseFloat(document.getElementById('beat').value);
+  const phase = parseFloat(document.getElementById('phase').value);
   const mode = document.getElementById('mode').value;
-  socket.send(JSON.stringify({ carrier, beat, mode }));
+  socket.send(JSON.stringify({ carrier, beat, phase_shift: phase, mode }));
 }
 
 document.getElementById('connect').onclick = () => start();

--- a/www/index.html
+++ b/www/index.html
@@ -80,6 +80,9 @@
     <label>Beat Frequency (Hz)
       <input id="beat" type="number" value="10" min="0.1" max="40" step="0.1">
     </label>
+    <label>Phase Shift (deg)
+      <input id="phase" type="number" value="0" min="0" max="360" step="1">
+    </label>
     <label>Mode
       <select id="mode">
         <option value="binaural">Binaural</option>


### PR DESCRIPTION
## Summary
- add `phase_shift` parameter to BeatGenerator
- validate phase ranges and forward parameter in server
- expose Phase Shift control in the web UI
- document new phase control

## Testing
- `python -m py_compile dsp/beat_generator.py server.py`
- `python - <<'PY'
from dsp.beat_generator import BeatGenerator
bg = BeatGenerator()
block = bg.generate(carrier=440, beat=10, mode='binaural', phase_shift=90)
print(block.shape)
print(block[:,0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6848fcb2dabc83248088104478b49d81