### PR TITLE
Handle CuPy init failures

### DIFF
--- a/dsp/beat_generator.py
+++ b/dsp/beat_generator.py
@@ -1,9 +1,21 @@
 import numpy as np
 
+# Attempt to import CuPy for GPU acceleration. If the library is missing or
+# fails to initialize (e.g. due to missing CUDA libraries), gracefully fall back
+# to NumPy so the application continues to work using the CPU.
 try:
-    import cupy as cp
-    gpu_available = True
-except ImportError:  # fallback to numpy
+    import cupy as _cp  # noqa: F401
+    try:
+        # A trivial operation to verify CUDA availability. Any failure here means
+        # we should not attempt to use the GPU backend.
+        _cp.zeros(1)
+        cp = _cp
+        gpu_available = True
+    except Exception as e:  # pragma: no cover - depends on system libs
+        print(f"CuPy initialization failed: {e}; falling back to CPU")
+        cp = np
+        gpu_available = False
+except ImportError:  # pragma: no cover - CuPy not installed
     cp = np
     gpu_available = False
 


### PR DESCRIPTION
## Summary
- gracefully fall back to CPU if CuPy fails to initialize
- add an empty favicon to avoid HTTP 404

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b94a726448324a0cc85f14fa5cb08