### PR TITLE
Fix local network access

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The server also hosts the frontend on port 8000 by default. Use `--http-port` to
 change it if needed.
 ```
 
-Then open `http://localhost:8000` in your browser and use the UI controls to adjust carrier frequency, beat frequency, phase shift and mode.
+Then open `http://localhost:8000` (or replace `localhost` with your machine's IP address to access it from another device on your network) and use the UI controls to adjust carrier frequency, beat frequency, phase shift and mode.
 
 ### Quick Ubuntu Setup
 

--- a/www/app.js
+++ b/www/app.js
@@ -3,7 +3,9 @@ let audioCtx;
 let workletNode;
 
 async function start() {
-  socket = new WebSocket('ws://localhost:8765');
+  const wsProto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const wsHost = window.location.hostname;
+  socket = new WebSocket(`${wsProto}://${wsHost}:8765`);
   audioCtx = new AudioContext();
   await audioCtx.audioWorklet.addModule('audio-worklet.js');
   workletNode = new AudioWorkletNode(audioCtx, 'buffer-player');


### PR DESCRIPTION
## Summary
- connect WebSocket using page hostname instead of localhost
- mention that you can replace `localhost` with server IP in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install websockets numpy simpleaudio` *(fails: simpleaudio build error)*

------
https://chatgpt.com/codex/tasks/task_e_684ba0a640a083249119e301048ca027