### PR TITLE
Improve playback buffering and add stop button

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -1,6 +1,7 @@
 let socket;
 let audioCtx;
 let workletNode;
+let paramInterval;
 
 async function start() {
   const wsProto = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -17,13 +18,37 @@ async function start() {
       workletNode.port.postMessage(ev.data);
     }
   };
+  socket.onopen = sendParams;
 
-  sendParams();
-  setInterval(sendParams, 1000);
+  paramInterval = setInterval(sendParams, 1000);
 
   const btn = document.getElementById('connect');
   if (btn) {
     btn.textContent = 'Playing';
+  }
+}
+
+function stop() {
+  if (paramInterval) {
+    clearInterval(paramInterval);
+    paramInterval = null;
+  }
+  if (socket) {
+    socket.close();
+    socket = null;
+  }
+  if (workletNode) {
+    workletNode.disconnect();
+    workletNode = null;
+  }
+  if (audioCtx) {
+    audioCtx.close();
+    audioCtx = null;
+  }
+
+  const btn = document.getElementById('connect');
+  if (btn) {
+    btn.textContent = 'Play';
   }
 }
 
@@ -36,3 +61,7 @@ function sendParams() {
 }
 
 document.getElementById('connect').onclick = () => start();
+const stopBtn = document.getElementById('stop');
+if (stopBtn) {
+  stopBtn.onclick = () => stop();
+}

--- a/www/audio-worklet.js
+++ b/www/audio-worklet.js
@@ -3,9 +3,14 @@ class BufferPlayer extends AudioWorkletProcessor {
     super();
     this.queue = [];
     this.readIndex = 0;
-    this.port.onmessage = e => {
+    this.ready = false;
+    this.port.onmessage = (e) => {
       const arr = new Float32Array(e.data);
       this.queue.push(arr);
+      if (this.queue.length >= 3) {
+        // Wait for a small buffer before starting playback
+        this.ready = true;
+      }
     };
   }
 
@@ -15,25 +20,30 @@ class BufferPlayer extends AudioWorkletProcessor {
       output[ch].fill(0);
     }
 
-    if (this.queue.length === 0) {
+    if (!this.ready || this.queue.length === 0) {
       return true;
     }
 
     const chunk = this.queue[0];
-    const framesPerBlock = 128;
-    for (let ch = 0; ch < output.length; ch++) {
-      for (let i = 0; i < framesPerBlock; i++) {
-        const idx = this.readIndex + i + ch * chunk.length / 2;
-        if (idx < chunk.length / 2) {
-          output[ch][i] = chunk[idx];
-        }
+    const framesPerBlock = output[0].length;
+    const half = chunk.length / 2;
+
+    for (let i = 0; i < framesPerBlock; i++) {
+      const lIdx = this.readIndex + i;
+      const rIdx = this.readIndex + i + half;
+      if (lIdx < half) {
+        output[0][i] = chunk[lIdx];
+        output[1][i] = chunk[rIdx];
       }
     }
 
     this.readIndex += framesPerBlock;
-    if (this.readIndex >= chunk.length / 2) {
+    if (this.readIndex >= half) {
       this.queue.shift();
       this.readIndex = 0;
+      if (this.queue.length < 1) {
+        this.ready = false;
+      }
     }
     return true;
   }

--- a/www/index.html
+++ b/www/index.html
@@ -43,7 +43,7 @@
       padding: 2px 4px;
       width: 80px;
     }
-    #connect {
+    #connect, #stop {
       display: block;
       margin: 10px auto;
       padding: 4px 20px;
@@ -90,6 +90,7 @@
       </select>
     </label>
     <button id="connect">Play</button>
+    <button id="stop">Stop</button>
     <div class="status" id="status"></div>
     <canvas id="scope" width="600" height="200"></canvas>
   </div>
@@ -97,12 +98,16 @@
   <script>
     // Basic feedback for play button
     const connectBtn = document.getElementById('connect');
+    const stopBtn = document.getElementById('stop');
     const statusDiv = document.getElementById('status');
     connectBtn.addEventListener('click', () => {
       statusDiv.textContent = "Connecting...";
       setTimeout(() => {
         statusDiv.textContent = "Playing...";
       }, 800);
+    });
+    stopBtn.addEventListener('click', () => {
+      statusDiv.textContent = "Stopped";
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- smooth playback by buffering audio before outputting
- add stop button to the web UI and hook up stop handler
- clean up `app.js` to handle connection lifecycle

## Testing
- `python -m py_compile server.py dsp/beat_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba3ab2a188324840f0b2a26191174