### PR TITLE
Improve audio stop behavior

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -9,7 +9,9 @@ async function start() {
   socket = new WebSocket(`${wsProto}://${wsHost}:8765`);
   audioCtx = new AudioContext();
   await audioCtx.audioWorklet.addModule('audio-worklet.js');
-  workletNode = new AudioWorkletNode(audioCtx, 'buffer-player');
+  workletNode = new AudioWorkletNode(audioCtx, 'buffer-player', {
+    outputChannelCount: [2]
+  });
   workletNode.connect(audioCtx.destination);
 
   socket.binaryType = 'arraybuffer';
@@ -38,6 +40,9 @@ function stop() {
     socket = null;
   }
   if (workletNode) {
+    try {
+      workletNode.port.postMessage({ command: 'stop' });
+    } catch (_) {}
     workletNode.disconnect();
     workletNode = null;
   }

--- a/www/audio-worklet.js
+++ b/www/audio-worklet.js
@@ -4,10 +4,17 @@ class BufferPlayer extends AudioWorkletProcessor {
     this.queue = [];
     this.readIndex = 0;
     this.ready = false;
+    this.minBlocks = 5;
     this.port.onmessage = (e) => {
+      if (e.data && e.data.command === 'stop') {
+        this.queue = [];
+        this.readIndex = 0;
+        this.ready = false;
+        return;
+      }
       const arr = new Float32Array(e.data);
       this.queue.push(arr);
-      if (this.queue.length >= 3) {
+      if (this.queue.length >= this.minBlocks) {
         // Wait for a small buffer before starting playback
         this.ready = true;
       }
@@ -41,7 +48,7 @@ class BufferPlayer extends AudioWorkletProcessor {
     if (this.readIndex >= half) {
       this.queue.shift();
       this.readIndex = 0;
-      if (this.queue.length < 1) {
+      if (this.queue.length < this.minBlocks) {
         this.ready = false;
       }
     }


### PR DESCRIPTION
## Summary
- enlarge playback buffer and handle stop messages in the AudioWorklet
- configure two output channels and flush buffers on stop in frontend

## Testing
- `python3 -m py_compile server.py dsp/beat_generator.py`
- `node --check www/app.js`
- `node --check www/audio-worklet.js`
- `python3 server.py --test-sweep` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `pip install websockets numpy simpleaudio cupy-cuda12x` *(fails: subprocess-exited-with-error building wheel for simpleaudio)*

------
https://chatgpt.com/codex/tasks/task_e_684ba53732f883249036b34ffbd82f69