### PR TITLE
Add frequency preset selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - 🧠 Experimental **resonance feedback AI agent** (coming soon)
 - 🌐 Cross-platform UI in-browser (works on Linux/Windows/macOS)
 - 🎨 Live channel visualizer and harmonic analysis
+- 🎚️ Quick-select frequency presets for common brainwave targets
 - 🔒 Fully self-hosted, no internet dependency
 
 ---

--- a/www/app.js
+++ b/www/app.js
@@ -2,6 +2,7 @@ let socket;
 let audioCtx;
 let workletNode;
 let paramInterval;
+let presets = [];
 
 async function start() {
   const wsProto = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -70,3 +71,33 @@ const stopBtn = document.getElementById('stop');
 if (stopBtn) {
   stopBtn.onclick = () => stop();
 }
+
+async function loadPresets() {
+  try {
+    const resp = await fetch('presets.json');
+    presets = await resp.json();
+    const select = document.getElementById('preset');
+    if (!select) return;
+    presets.forEach((p, idx) => {
+      const opt = document.createElement('option');
+      opt.value = idx;
+      opt.textContent = p.name;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => {
+      const idx = parseInt(select.value);
+      if (isNaN(idx)) return;
+      const p = presets[idx];
+      document.getElementById('carrier').value = p.carrier;
+      document.getElementById('beat').value = p.beat;
+      document.getElementById('mode').value = p.type || 'binaural';
+      const notes = document.getElementById('preset-notes');
+      if (notes) notes.textContent = p.notes || '';
+      sendParams();
+    });
+  } catch (e) {
+    console.error('Failed to load presets', e);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', loadPresets);

--- a/www/index.html
+++ b/www/index.html
@@ -8,7 +8,7 @@
     body {
       font-family: Tahoma, sans-serif;
       margin: 0;
-      background: #000;
+      background: linear-gradient(#1a1a1a, #000);
       color: #eee;
     }
     .header {
@@ -66,6 +66,13 @@
       background: #000;
       border: 1px solid #555;
     }
+    .notes {
+      margin-top: 8px;
+      text-align: center;
+      font-size: 0.85em;
+      color: #ffcc00;
+      min-height: 1.2em;
+    }
   </style>
 </head>
 <body>
@@ -83,6 +90,11 @@
     <label>Phase Shift (deg)
       <input id="phase" type="number" value="0" min="0" max="360" step="1">
     </label>
+    <label>Preset
+      <select id="preset">
+        <option value="">Select...</option>
+      </select>
+    </label>
     <label>Mode
       <select id="mode">
         <option value="binaural">Binaural</option>
@@ -93,6 +105,7 @@
     <button id="stop">Stop</button>
     <div class="status" id="status"></div>
     <canvas id="scope" width="600" height="200"></canvas>
+    <div class="notes" id="preset-notes"></div>
   </div>
   <script src="app.js"></script>
   <script>

--- a/www/presets.json
+++ b/www/presets.json
@@ -1,0 +1,6 @@
+[
+  {"name": "Delta Sleep", "carrier": 250, "beat": 2, "type": "monaural", "notes": "Pink noise on, deep rest"},
+  {"name": "Theta Focus", "carrier": 400, "beat": 6, "type": "binaural", "notes": "Meditation, creativity"},
+  {"name": "Alpha Calm", "carrier": 400, "beat": 10, "type": "monaural", "notes": "Stress reduction"},
+  {"name": "Gamma Cognition", "carrier": 400, "beat": 40, "type": "monaural", "notes": "Memory & attention"}
+]


### PR DESCRIPTION
## Summary
- add dropdown to quickly load frequency presets
- style body with a subtle gradient and show preset notes
- populate presets from `presets.json`
- document preset functionality in README

## Testing
- `python -m py_compile server.py dsp/beat_generator.py`
- `node --check www/app.js`
- `node --check www/audio-worklet.js`
- `python server.py --test-sweep` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6851a036f7ac8324bc7c192b47de1222