### PR TITLE
Use sounddevice for test audio

### DIFF
--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -8,7 +8,7 @@ sudo apt-get update
 # Install system packages
 sudo apt-get install -y \
     python3 python3-venv python3-pip \
-    build-essential libasound2-dev
+    build-essential libasound2-dev portaudio19-dev
 
 # Node.js is optional for frontend tooling and is no longer installed
 # automatically to avoid package conflicts. Install it separately if needed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 websockets
 numpy
 cupy-cuda12x; platform_system=="Linux"
-simpleaudio
+sounddevice

--- a/server.py
+++ b/server.py
@@ -9,7 +9,7 @@ import struct
 import websockets
 import argparse
 import numpy as np
-import simpleaudio as sa
+import sounddevice as sd
 import http.server
 import threading
 import functools
@@ -52,8 +52,8 @@ def play_test_sweep(duration=5.0, start=200.0, end=800.0):
     freqs = np.linspace(start, end, t.size)
     wave = np.sin(2 * np.pi * freqs * t)
     stereo = np.stack([wave, wave], axis=1)
-    audio = (stereo * 32767).astype(np.int16)
-    sa.play_buffer(audio, 2, 2, SAMPLE_RATE).wait_done()
+    sd.play(stereo, SAMPLE_RATE)
+    sd.wait()
 
 def start_static_server(port=8000, directory="www"):
     """Launch a simple HTTP server to host the frontend."""


### PR DESCRIPTION
## Summary
- switch test sweep playback from `simpleaudio` to `sounddevice`
- install required PortAudio development package on Ubuntu
- update dependency list

## Testing
- `python -m py_compile server.py dsp/beat_generator.py`
- `pip install --no-cache-dir -r requirements.txt`
- `apt-get update`
- `apt-get install -y portaudio19-dev`
- `python server.py --test-sweep` *(fails: sounddevice.PortAudioError - Error querying device)*

------
https://chatgpt.com/codex/tasks/task_e_68523bcdf2208324ac19c529c1109efb