### PR TITLE
Add amplitude and filter controls to beat generator

### DIFF
--- a/dsp/beat_generator.py
+++ b/dsp/beat_generator.py
@@ -23,17 +23,56 @@ except ImportError:  # pragma: no cover - CuPy not installed
 class BeatGenerator:
     """Generate binaural or monaural beats using GPU if available."""
 
-    def __init__(self, sample_rate=48000, block_size=2048, device='gpu'):
+    def __init__(self, sample_rate=48000, block_size=2048, device='gpu',
+                 filter_cutoff=None):
+        """Create a new beat generator.
+
+        Parameters
+        ----------
+        sample_rate : int
+            Output sample rate in Hz.
+        block_size : int
+            Number of samples per generated block.
+        device : str
+            ``"gpu"`` or ``"cpu"``. Falls back to CPU if GPU unavailable.
+        filter_cutoff : float or None, optional
+            Cutoff frequency for the optional low-pass filter in Hz. ``None``
+            disables the filter.
+        """
         self.sample_rate = sample_rate
         self.block_size = block_size
         self.device = device if gpu_available and device == 'gpu' else 'cpu'
         self.phase_left = 0.0
         self.phase_right = 0.0
+        self.filter_cutoff = filter_cutoff
+        self._filter_state_left = 0.0
+        self._filter_state_right = 0.0
 
     def _xp(self):
         return cp if self.device == 'gpu' else np
 
-    def generate(self, carrier=400.0, beat=10.0, mode='binaural', phase_shift=0.0):
+    def _lowpass_cpu(self, x, cutoff, state):
+        """Simple single-pole low-pass filter for 1D arrays."""
+        if cutoff is None:
+            return x, state
+        dt = 1.0 / self.sample_rate
+        rc = 1.0 / (2.0 * np.pi * cutoff)
+        alpha = dt / (rc + dt)
+        out = np.empty_like(x)
+        for i, sample in enumerate(x):
+            state = state + alpha * (sample - state)
+            out[i] = state
+        return out, state
+
+    def _lowpass(self, arr, cutoff, state):
+        xp = self._xp()
+        if self.device == 'gpu':
+            cpu_arr, state = self._lowpass_cpu(cp.asnumpy(arr), cutoff, state)
+            return cp.asarray(cpu_arr), state
+        return self._lowpass_cpu(arr, cutoff, state)
+
+    def generate(self, carrier=400.0, beat=10.0, mode='binaural', phase_shift=0.0,
+                 amplitude=1.0, filter_cutoff=None):
         """Generate a block of audio samples.
 
         Parameters
@@ -46,9 +85,12 @@ class BeatGenerator:
             Either ``'binaural'`` or ``'monaural'``.
         phase_shift : float
             Relative phase shift between left and right channels in degrees.
+        amplitude : float, optional
+            Output volume multiplier. ``1.0`` is unchanged.
+        filter_cutoff : float or None, optional
+            Override the object's ``filter_cutoff`` for this call.
         """
         xp = self._xp()
-        t = xp.arange(self.block_size, dtype=xp.float64) / self.sample_rate
 
         if mode == 'binaural':
             left_freq = carrier - beat / 2.0
@@ -72,6 +114,20 @@ class BeatGenerator:
         self.phase_left = float((phase_vec_left[-1] + phase_inc_left) % (2 * xp.pi))
         next_right = (base_right[-1] + phase_inc_right) % (2 * xp.pi)
         self.phase_right = float(next_right)
+
+        # Optional low-pass filtering to reduce high-frequency static
+        cutoff = filter_cutoff if filter_cutoff is not None else self.filter_cutoff
+        if cutoff is not None:
+            left, self._filter_state_left = self._lowpass(
+                left, cutoff, self._filter_state_left
+            )
+            right, self._filter_state_right = self._lowpass(
+                right, cutoff, self._filter_state_right
+            )
+
+        if amplitude != 1.0:
+            left *= amplitude
+            right *= amplitude
 
         if mode == 'monaural':
             mono = (left + right) * 0.5

--- a/server.py
+++ b/server.py
@@ -44,6 +44,15 @@ def validate_params(params):
     if not (0.0 <= params.get('phase_shift', 0.0) <= 360.0):
         print("Phase shift out of range. Setting to default (0.0).")
         params['phase_shift'] = 0.0
+    amp = params.get('amplitude', 1.0)
+    if not (0.0 <= amp <= 2.0):
+        print("Amplitude out of range. Setting to default (1.0).")
+        params['amplitude'] = 1.0
+    cutoff = params.get('filter_cutoff')
+    if cutoff is not None:
+        if not (10.0 <= cutoff <= params.get('sample_rate', SAMPLE_RATE) / 2):
+            print("Filter cutoff out of range. Disabling filter.")
+            params['filter_cutoff'] = None
     # You may add more param validation as needed
 
 def play_test_sweep(duration=5.0, start=200.0, end=800.0):
@@ -78,6 +87,8 @@ async def audio_stream(websocket):
         'beat': 10.0,
         'mode': 'binaural',
         'phase_shift': 0.0,
+        'amplitude': 1.0,
+        'filter_cutoff': None,
     }
 
     async def recv_loop():
@@ -86,6 +97,7 @@ async def audio_stream(websocket):
                 updates = json.loads(msg)
                 params.update(updates)
                 validate_params(params)
+                generator.filter_cutoff = params.get('filter_cutoff')
                 if DEBUG:
                     print(f"Received updates: {updates}")
                     print(f"Updated params: {params}")

--- a/www/app.js
+++ b/www/app.js
@@ -62,8 +62,13 @@ function sendParams() {
   const carrier = parseFloat(document.getElementById('carrier').value);
   const beat = parseFloat(document.getElementById('beat').value);
   const phase = parseFloat(document.getElementById('phase').value);
+  const amplitude = parseFloat(document.getElementById('amplitude').value);
+  const cutoffInput = document.getElementById('filter_cutoff').value;
+  const filter_cutoff = cutoffInput === '' ? null : parseFloat(cutoffInput);
   const mode = document.getElementById('mode').value;
-  socket.send(JSON.stringify({ carrier, beat, phase_shift: phase, mode }));
+  socket.send(
+    JSON.stringify({ carrier, beat, phase_shift: phase, amplitude, filter_cutoff, mode })
+  );
 }
 
 document.getElementById('connect').onclick = () => start();
@@ -91,6 +96,13 @@ async function loadPresets() {
       document.getElementById('carrier').value = p.carrier;
       document.getElementById('beat').value = p.beat;
       document.getElementById('mode').value = p.type || 'binaural';
+      if (p.amplitude !== undefined) {
+        document.getElementById('amplitude').value = p.amplitude;
+      }
+      if (p.filter_cutoff !== undefined) {
+        const fcField = document.getElementById('filter_cutoff');
+        fcField.value = p.filter_cutoff === null ? '' : p.filter_cutoff;
+      }
       const notes = document.getElementById('preset-notes');
       if (notes) notes.textContent = p.notes || '';
       sendParams();

--- a/www/index.html
+++ b/www/index.html
@@ -90,6 +90,12 @@
     <label>Phase Shift (deg)
       <input id="phase" type="number" value="0" min="0" max="360" step="1">
     </label>
+    <label>Amplitude
+      <input id="amplitude" type="number" value="1.0" min="0" max="2" step="0.01">
+    </label>
+    <label>Filter Cutoff (Hz)
+      <input id="filter_cutoff" type="number" value="" placeholder="off" min="10" max="20000" step="10">
+    </label>
     <label>Preset
       <select id="preset">
         <option value="">Select...</option>


### PR DESCRIPTION
## Summary
- improve `BeatGenerator` constructor docs and add amplitude+filter options
- validate new params in `server.py`
- expose amplitude and low-pass cutoff in the browser UI

## Testing
- `python -m py_compile dsp/beat_generator.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68523da8dc608324b4af27af3a39ceab