### PR TITLE
Improve error handling and user feedback

### DIFF
--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -3,23 +3,23 @@
 set -e
 
 # Update package lists
-sudo apt-get update
+sudo apt-get update || { echo "Failed to update package list" >&2; exit 1; }
 
 # Install system packages
 sudo apt-get install -y \
     python3 python3-venv python3-pip \
-    build-essential libasound2-dev portaudio19-dev
+    build-essential libasound2-dev portaudio19-dev || { echo "Package installation failed" >&2; exit 1; }
 
 # Node.js is optional for frontend tooling and is no longer installed
 # automatically to avoid package conflicts. Install it separately if needed.
 
 # Create and activate virtual environment
-python3 -m venv hemi_env
-source hemi_env/bin/activate
+python3 -m venv hemi_env || { echo "Virtualenv creation failed" >&2; exit 1; }
+source hemi_env/bin/activate || { echo "Failed to activate virtualenv" >&2; exit 1; }
 
 # Upgrade pip and install Python dependencies
-pip install --upgrade pip
-pip install -r requirements.txt
+pip install --upgrade pip || { echo "Pip upgrade failed" >&2; exit 1; }
+pip install -r requirements.txt || { echo "Python dependencies failed" >&2; exit 1; }
 
 cat <<'EOM'
 Installation complete.

--- a/setup.sh
+++ b/setup.sh
@@ -6,15 +6,15 @@ set -e
 
 # Create virtual environment if it doesn't exist
 if [ ! -d "venv" ]; then
-    python3 -m venv venv
+    python3 -m venv venv || { echo "Failed to create virtual environment" >&2; exit 1; }
 fi
 
 # Activate environment
-source venv/bin/activate
+source venv/bin/activate || { echo "Failed to activate virtualenv" >&2; exit 1; }
 
 # Upgrade pip and install requirements
-python -m pip install --upgrade pip
-pip install -r requirements.txt
+python -m pip install --upgrade pip || { echo "Pip upgrade failed" >&2; exit 1; }
+pip install -r requirements.txt || { echo "Requirements installation failed" >&2; exit 1; }
 
 cat <<'EOM'
 Environment setup complete.


### PR DESCRIPTION
## Summary
- send parameter validation errors to frontend
- surface connection issues and preset load failures in the UI
- show detailed failure messages in setup scripts
- catch startup `OSError` when server fails

## Testing
- `python -m py_compile server.py dsp/beat_generator.py`
- `bash -n install_ubuntu.sh`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852ea3c27988324b3e13684772c71ba