### PR TITLE
Fix audio playback initialization

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -13,6 +13,15 @@ let animId;
 async function start() {
   audioCtx = new AudioContext();
   await audioCtx.audioWorklet.addModule('oscillator-worklet.js');
+  // Some browsers start AudioContext in a suspended state until resumed.
+  // Calling resume here ensures playback begins after the user click.
+  if (audioCtx.state === 'suspended') {
+    try {
+      await audioCtx.resume();
+    } catch (e) {
+      console.error('Failed to resume AudioContext', e);
+    }
+  }
   workletNode = new AudioWorkletNode(audioCtx, 'oscillator-generator', {
     outputChannelCount: [2]
   });


### PR DESCRIPTION
## Summary
- resume the AudioContext after loading the oscillator worklet

## Testing
- `node --check www/app.js`
- `python server.py --test-sweep` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6859fca3cc5c8324a24335ab486b1ff4