### PR TITLE
Fix UI initialization for slider readouts

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -151,11 +151,14 @@ function drawScope() {
   animId = requestAnimationFrame(drawScope);
 }
 
-document.getElementById('connect').onclick = () => start();
-const stopBtn = document.getElementById('stop');
-if (stopBtn) {
-  stopBtn.onclick = () => stop();
-}
+// Attach UI event handlers after the DOM has loaded to avoid null lookups
+window.addEventListener('DOMContentLoaded', () => {
+  const playBtn = document.getElementById('connect');
+  if (playBtn) playBtn.addEventListener('click', () => start());
+
+  const stopBtn = document.getElementById('stop');
+  if (stopBtn) stopBtn.addEventListener('click', () => stop());
+});
 
 async function loadPresets() {
   try {

--- a/www/index.html
+++ b/www/index.html
@@ -146,30 +146,36 @@
   </div>
   <script src="app.js"></script>
   <script>
-    // Basic feedback for play button
-    const connectBtn = document.getElementById('connect');
-    const stopBtn = document.getElementById('stop');
-    const statusDiv = document.getElementById('status');
-    connectBtn.addEventListener('click', () => {
-      statusDiv.textContent = "Playing...";
-    });
-    stopBtn.addEventListener('click', () => {
-      statusDiv.textContent = "Stopped";
-    });
-
-    // Update text outputs for sliders
-    ['carrier', 'beat', 'phase', 'amplitude'].forEach((id) => {
-      const slider = document.getElementById(id);
-      const out = document.getElementById(id + '_val');
-      if (slider && out) {
-        out.textContent = slider.value;
-        slider.addEventListener('input', () => {
-          out.textContent = slider.value;
-          if (typeof sendParams === 'function') {
-            sendParams();
-          }
+    window.addEventListener('DOMContentLoaded', () => {
+      // Basic feedback for play button
+      const connectBtn = document.getElementById('connect');
+      const stopBtn = document.getElementById('stop');
+      const statusDiv = document.getElementById('status');
+      if (connectBtn) {
+        connectBtn.addEventListener('click', () => {
+          statusDiv.textContent = 'Playing...';
         });
       }
+      if (stopBtn) {
+        stopBtn.addEventListener('click', () => {
+          statusDiv.textContent = 'Stopped';
+        });
+      }
+
+      // Update text outputs for sliders
+      ['carrier', 'beat', 'phase', 'amplitude'].forEach((id) => {
+        const slider = document.getElementById(id);
+        const out = document.getElementById(id + '_val');
+        if (slider && out) {
+          out.textContent = slider.value;
+          slider.addEventListener('input', () => {
+            out.textContent = slider.value;
+            if (typeof sendParams === 'function') {
+              sendParams();
+            }
+          });
+        }
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- attach button handlers after DOMContentLoaded so script doesn't crash when elements aren't ready
- run slider update code after DOM load

## Testing
- `python -m py_compile dsp/beat_generator.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_685a069878f083249def295d9c3ab9ed