### PR TITLE
Fix missing worklet module path

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -15,7 +15,11 @@ async function start() {
     audioCtx = new AudioContext();
     
     // Load the enhanced worklet
-    await audioCtx.audioWorklet.addModule('enhanced-oscillator-worklet.js');
+    // Load the worklet module. This file registers the
+    // 'enhanced-oscillator-generator' processor.
+    // The original path pointed to a non-existent file which
+    // caused a DOMException when starting audio.
+    await audioCtx.audioWorklet.addModule('oscillator-worklet.js');
     
     // Resume context if suspended
     if (audioCtx.state === 'suspended') {


### PR DESCRIPTION
## Summary
- load the oscillator worklet from the correct filename

## Testing
- `python server.py --test-sweep`
- `python -m py_compile dsp/beat_generator.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_6861a9582ce083248314d69326d38442